### PR TITLE
Updated recommened platforms install command

### DIFF
--- a/platformio/exception.py
+++ b/platformio/exception.py
@@ -30,7 +30,7 @@ class UnknownPlatform(PlatformioException):
 class PlatformNotInstalledYet(PlatformioException):
 
     MESSAGE = ("The platform '%s' has not been installed yet. "
-               "Use `platformio install` command")
+               "Use `platformio platforms install` command")
 
 
 class UnknownCLICommand(PlatformioException):


### PR DESCRIPTION
`$ platformio install [platform]`
The above line is obsolete, I've changed the recommendation to reflect this latest version of the program:
`$ platformio platforms install [platform]`