### PR TITLE
improved error wording

### DIFF
--- a/platformio/builder/tools/pioupload.py
+++ b/platformio/builder/tools/pioupload.py
@@ -90,7 +90,8 @@ def AutodetectUploadPort(env):
     else:
         Exit("Error: Please specify `upload_port` for environment or use "
              "global `--upload-port` option.\n"
-             "For the some development platforms it can be USB flash drive\n")
+             "For some development platforms this can be a USB flash drive "
+             "(i.e. /media/<user>/<device name>)\n")
 
 
 def UploadToDisk(_, target, source, env):  # pylint: disable=W0613,W0621


### PR DESCRIPTION
Fixed a grammatical mistake, made the meaning  of the error clearer by replacing "it" with "this" and by adding an example.

It does increase the length of the output, but I think it's much easier to read and more informative.