### PR TITLE
Add external programmer and SPIFFS targets to Emacs

### DIFF
--- a/docs/ide/emacs.rst
+++ b/docs/ide/emacs.rst
@@ -57,12 +57,14 @@ command and generate project via :option:`platformio init --ide` command:
     cmake .
 
 
-There are 4 predefined targets for building.
+There are 6 predefined targets for building.
 
-* ``platformio_build``  - Build project without auto-uploading.     (``C-c i b``)
-* ``platformio_upload`` - Build and upload (if no errors).          (``C-c i u``)
-* ``platformio_clean``  - Clean compiled objects.                   (``C-c i c``)
-* ``platformio_update`` - Update installed platforms and libraries. (``C-c i d``)
+* ``platformio_build``  - Build project without auto-uploading.        (``C-c i b``)
+* ``platformio_upload`` - Build and upload (if no errors).             (``C-c i u``)
+* ``platformio_programmer_upload`` - Build and upload using external programmer (if no errors). (``C-c i p``)
+* ``platformio_spiffs_upload``  - Upload files to file system SPIFFS). (``C-c i s``)
+* ``platformio_clean``  - Clean compiled objects.                      (``C-c i c``)
+* ``platformio_update`` - Update installed platforms and libraries.    (``C-c i d``)
 
 .. warning::
     The libraries which are added, installed or used in the project

--- a/platformio/ide/tpls/emacs/CMakeLists.txt.tpl
+++ b/platformio/ide/tpls/emacs/CMakeLists.txt.tpl
@@ -40,6 +40,18 @@ add_custom_target(
 )
 
 add_custom_target(
+    platformio_programmer_upload ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c emacs run --target program
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    platformio_spiffs_upload ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c emacs run --target uploadfs
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
     platformio_update ALL
     COMMAND ${PLATFORMIO_CMD} -f -c emacs update
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
As per #427.

Added in the remaining targets to my `CMakeLists.txt` file and updated the docs with the new key bindings.

I've already pushed the corresponding changes to the Emacs package: ZachMassia/@69d584003332908f49f25fb614ed67925a23a578