### PR TITLE
https://github.com/openstack/pylockfile

### DIFF
--- a/platformio/app.py
+++ b/platformio/app.py
@@ -18,7 +18,7 @@ from os import environ, getenv
 from os.path import getmtime, isfile, join
 from time import time
 
-from lockfile import LockFile
+from lockfile import FileLock
 
 from platformio import __version__
 from platformio.exception import InvalidSettingName, InvalidSettingValue
@@ -104,7 +104,7 @@ class State(object):
     def _lock_state_file(self):
         if not self.lock:
             return
-        self._lockfile = LockFile(self.path)
+        self._lockfile = FileLock(self.path)
 
         if (self._lockfile.is_locked() and
                 (time() - getmtime(self._lockfile.lock_file)) > 10):


### PR DESCRIPTION
Warning

This package is deprecated. It is highly preferred that instead of using this code base that instead fasteners or oslo.concurrency is used instead.

The lockfile package exports a LockFile class which provides a simple API for locking files. Unlike the Windows msvcrt.locking function, the fcntl.lockf and fcntl.flock functions, and the deprecated posixfile module, the API is identical across both UNIX (including Linux and Mac) and Windows platforms.

The lock mechanism relies on the atomic nature of the link (on UNIX) and mkdir (on Windows) system calls. An implementation based on SQLite is also provided, more as a demonstration of the possibilities it provides than as production-quality code.

Install pylockfile with: pip install lockfile.

Documentation
Source
Bugs
For any questions or comments or further help needed please email openstack-dev and prefix your email subject with [oslo][pylockfile] (for a faster response).

In version 0.9 the API changed in two significant ways:

It changed from a module defining several classes to a package containing several modules, each defining a single class.
Where classes had been named SomethingFileLock before the last two words have been reversed, so that class is now SomethingLockFile.
The previous module-level definitions of LinkFileLock, MkdirFileLock and SQLiteFileLock will be retained until the 1.0 release.