### PR TITLE
Added -std=gnu++11 flag to atmelsam

### DIFF
--- a/platformio/builder/scripts/atmelsam.py
+++ b/platformio/builder/scripts/atmelsam.py
@@ -96,7 +96,8 @@ else:
 
 env.Append(
     CXXFLAGS=[
-        "-fno-threadsafe-statics"
+        "-fno-threadsafe-statics",
+        "-std=gnu++11"
     ],
 
     CPPDEFINES=[


### PR DESCRIPTION
Hello! Thanks for a splendid project!

At this moment the following code will not compile for Due or Zero boards. But the same code will compile in Arduino IDE (1.6.8).

```Arduino
void setup() {
  char *foo = nullptr; // check if c++11 is available
}

void loop() {
}
```

I'm not sure if my change is not in conflict with something else. There is also the same flag for Zero in arduino.py:266
https://github.com/platformio/platformio/blob/develop/platformio/builder/scripts/frameworks/arduino.py#L266