### PR TITLE
FIX inserted correct information for OpenBCI

### DIFF
--- a/platformio/boards/microchippic32.json
+++ b/platformio/boards/microchippic32.json
@@ -561,7 +561,7 @@
             "variant": "OpenBCI"
         },
         "frameworks": ["arduino"],
-        "name": "Digilent OpenScope",
+        "name": "OpenBCI 32bit",
         "platform": "microchippic32",
         "upload": {
             "maximum_ram_size": 32768,
@@ -571,7 +571,7 @@
             "speed": 115200,
             "wait_for_upload_port": true
         },
-        "url": "http://store.digilentinc.com/",
-        "vendor": "Digilent"
+        "url": "http://shop.openbci.com/",
+        "vendor": "OpenBCI"
     }
 }


### PR DESCRIPTION
Incorrect information for OpenBCI variant, led to a double entry for "OpenScope" under board selection dropdown. 