### PR TITLE
add --enable_upload functionality to "pio ci"

### DIFF
--- a/docs/userguide/cmd_ci.rst
+++ b/docs/userguide/cmd_ci.rst
@@ -105,6 +105,12 @@ temporary directory within your operation system.
 Don't remove :option:`platformio ci --build-dir` after build process.
 
 .. option::
+    --enable_upload
+
+Target upload after build. So it possible to upload a examble or *.ino file
+direct without create a project.
+
+.. option::
     --project-conf
 
 Buid project using pre-configured :ref:`projectconf`.

--- a/platformio/commands/ci.py
+++ b/platformio/commands/ci.py
@@ -100,11 +100,8 @@ def cli(ctx, src, lib, exclude, board,  # pylint: disable=R0913
             _exclude_contents(build_dir, exclude)
 
         # initialise project
-        if not enable_upload:
-            ctx.invoke(cmd_init, project_dir=build_dir, board=board)
-        else:
-            ctx.invoke(cmd_init, enable_auto_uploading=True,
-                       project_dir=build_dir, board=board)
+        ctx.invoke(cmd_init, enable_auto_uploading=enable_upload,
+                   project_dir=build_dir, board=board)
 
         # process project
         ctx.invoke(cmd_run, project_dir=build_dir, verbose=verbose)

--- a/platformio/commands/ci.py
+++ b/platformio/commands/ci.py
@@ -65,13 +65,14 @@ def validate_boards(ctx, param, value):  # pylint: disable=W0613
               type=click.Path(exists=True, file_okay=False, dir_okay=True,
                               writable=True, resolve_path=True))
 @click.option("--keep-build-dir", is_flag=True)
+@click.option("--enable-upload", is_flag=True)
 @click.option("--project-conf",
               type=click.Path(exists=True, file_okay=True, dir_okay=False,
                               readable=True, resolve_path=True))
 @click.option("--verbose", "-v", count=True, default=3)
 @click.pass_context
 def cli(ctx, src, lib, exclude, board,  # pylint: disable=R0913
-        build_dir, keep_build_dir, project_conf, verbose):
+        build_dir, keep_build_dir, enable_upload, project_conf, verbose):
 
     if not src:
         src = getenv("PLATFORMIO_CI_SRC", "").split(":")
@@ -99,10 +100,15 @@ def cli(ctx, src, lib, exclude, board,  # pylint: disable=R0913
             _exclude_contents(build_dir, exclude)
 
         # initialise project
-        ctx.invoke(cmd_init, project_dir=build_dir, board=board)
+        if not enable_upload:
+            ctx.invoke(cmd_init, project_dir=build_dir, board=board)
+        else:
+            ctx.invoke(cmd_init, enable_auto_uploading=True,
+                       project_dir=build_dir, board=board)
 
         # process project
         ctx.invoke(cmd_run, project_dir=build_dir, verbose=verbose)
+
     finally:
         if not keep_build_dir:
             rmtree(


### PR DESCRIPTION
I think it is a big benefit for library developers. It help to compile a examble or test file direct for uploading and don't need create a temp project anymore.

It also possible to compile a single i.e. ino file from a examble or other source to microcontroller without create a dumy project.