### PR TITLE
Apply BuildDependentLibraries to src_filter dirs

### DIFF
--- a/platformio/builder/tools/platformio.py
+++ b/platformio/builder/tools/platformio.py
@@ -61,7 +61,7 @@ def BuildProgram(env):
             f.lower().strip() for f in env.get("FRAMEWORK", "").split(",")])
 
     # build dependent libs
-    deplibs = env.BuildDependentLibraries("$PROJECTSRC_DIR")
+    deplibs = env.BuildDependentLibraries("$PROJECTSRC_DIR", src_filter=env.get("SRC_FILTER"))
 
     # append specified LD_SCRIPT
     if ("LDSCRIPT_PATH" in env and
@@ -164,10 +164,9 @@ def VariantDirWrap(env, variant_dir, src_dir, duplicate=True):
     DefaultEnvironment().Append(VARIANT_DIRS=[(variant_dir, src_dir)])
     env.VariantDir(variant_dir, src_dir, duplicate)
 
+SRC_FILTER_PATTERNS_RE = re.compile(r"(\+|\-)<([^>]+)>")
 
 def LookupSources(env, variant_dir, src_dir, duplicate=True, src_filter=None):
-
-    SRC_FILTER_PATTERNS_RE = re.compile(r"(\+|\-)<([^>]+)>")
 
     def _append_build_item(items, item, src_dir):
         if env.IsFileWithExt(item, SRC_BUILD_EXT + SRC_HEADER_EXT):
@@ -244,7 +243,10 @@ def BuildLibrary(env, variant_dir, src_dir, src_filter=None):
     )
 
 
-def BuildDependentLibraries(env, src_dir):  # pylint: disable=R0914
+def BuildDependentLibraries(env, src_dir, src_filter=None):  # pylint: disable=R0914
+    # correct fs directory separator
+    if (src_filter):
+        src_filter = src_filter.replace("/", sep).replace("\\", sep)
 
     INCLUDES_RE = re.compile(
         r"^\s*#include\s+(\<|\")([^\>\"\']+)(?:\>|\")", re.M)
@@ -323,8 +325,18 @@ def BuildDependentLibraries(env, src_dir):  # pylint: disable=R0914
             "libs": set(),
             "ordered": set()
         }
+        
+        import os
+        # Determine all directories which are listed in src_filter (marked with a "+").
+        src_dir_l = env.subst(src_dir)
+        src_dirs = set()
+        for (action, pattern) in SRC_FILTER_PATTERNS_RE.findall(src_filter):
+            if action == "+":
+                for item in glob(join(src_dir_l, pattern)):
+                    src_dirs.add(os.path.dirname(item))
 
-        state = _process_src_dir(state, env.subst(src_dir))
+        for src_dir_l in src_dirs:
+            state = _process_src_dir(state, src_dir_l)
 
         result = []
         for item in sorted(state['ordered'], key=lambda s: s[0]):


### PR DESCRIPTION
At the moment BuildDependentLibraries (scanning source files for lib
includes) is only executed for the _src_ directory, even if _src_filter_
brings in other directories. This few lines of code changes apply the
scanning to all additional dirs mentioned in src_filter with a "+".

## Use cases
Have targets in your platformio.ini which references additional source directories via the src_filter.

1) In my case i want to target an arduino and an esp8266 board. The core logic
    of my library is platform independant but some few files are board specific, so I need
    to pull them in via src_filter (which works great). This pull request allows mentioned
    libraries in those additional files to be handled like if the source files reside in "src/".

2) If you provide some examples with a library, at the moment it is difficult to provide the user
    a simple way to build an example. With this pull request the user just builds one of the
    targets in the platformio.ini which lists the example source files via src_filter. E.g.:

`[platformio]
src_dir = src/

[env:nodemcuv2lib]
platform = espressif
framework = arduino
board = nodemcuv2

[env:nodemcuv2Example1]
platform = espressif
framework = arduino
board = nodemcuv2
src_filter = +<\*> +<../examples/example1/src/*>`